### PR TITLE
Fix some PHP 8 errors

### DIFF
--- a/src/Helper/NovalnetHelper.php
+++ b/src/Helper/NovalnetHelper.php
@@ -121,14 +121,14 @@ class NovalnetHelper
            'street'            => $objBillingAddress->street_1,
               'city'              => $objBillingAddress->city,
               'zip'               => $objBillingAddress->postal,
-              'country_code'      => strtoupper($objBillingAddress->country),
+              'country_code'      => strtoupper($objBillingAddress->country ?? ''),
         );
 
         $request['customer']['shipping'] = array(
             'street'            => $objShippingAddress->street_1,
               'city'              => $objShippingAddress->city,
               'zip'               => $objShippingAddress->postal,
-              'country_code'      => strtoupper($objShippingAddress->country),
+              'country_code'      => strtoupper($objShippingAddress->country ?? ''),
         );
         if ($request['customer']['billing'] == $request['customer']['shipping']) {
             $request['customer']['shipping'] = array(


### PR DESCRIPTION
Fixes errors like these:

```
TypeError: strtoupper(): Argument #1 ($string) must be of type string, null given
#39 /vendor/novalnet-gateway/isotope-novalnet/src/Helper/NovalnetHelper.php(131): strtoupper
#38 /vendor/novalnet-gateway/isotope-novalnet/src/Helper/NovalnetHelper.php(131): NovalnetGateway\IsotopeNovalnetBundle\Helper\NovalnetHelper::formCustomerParameters
#37 /vendor/novalnet-gateway/isotope-novalnet/src/Helper/NovalnetHelper.php(56): NovalnetGateway\IsotopeNovalnetBundle\Helper\NovalnetHelper::buildNovalnetParams
#36 /vendor/novalnet-gateway/isotope-novalnet/src/Isotope/Model/Payment/NovalnetEps.php(68): NovalnetGateway\IsotopeNovalnetBundle\Isotope\Model\Payment\NovalnetEps::checkoutForm
#35 /vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Module/Checkout.php(240): Isotope\Module\Checkout::compile
…
```