### PR TITLE
Fix orders with amounts greater than 999 only charging 1.00

### DIFF
--- a/src/Helper/NovalnetHelper.php
+++ b/src/Helper/NovalnetHelper.php
@@ -191,7 +191,7 @@ class NovalnetHelper
     {
         $request['transaction'] = array(
           'payment_type'     => $this->paymentType[$currentPayment],
-          'amount'           => number_format($order->getTotal(), 2)*100,           
+          'amount'           => number_format($order->getTotal(), 2, '.', '')*100,
           'currency'         => $order->getCurrency(),          
           'system_url'       => \Environment::get('base') ,
           'return_url'       => \Environment::get('base') . Checkout::generateUrlForStep(Checkout::STEP_COMPLETE, $order),

--- a/src/Helper/NovalnetHelper.php
+++ b/src/Helper/NovalnetHelper.php
@@ -191,7 +191,7 @@ class NovalnetHelper
     {
         $request['transaction'] = array(
           'payment_type'     => $this->paymentType[$currentPayment],
-          'amount'           => number_format($order->getTotal(), 2, '.', '')*100,
+          'amount'           => floatval(number_format($order->getTotal(), 2, '.', ''))*100,           
           'currency'         => $order->getCurrency(),          
           'system_url'       => \Environment::get('base') ,
           'return_url'       => \Environment::get('base') . Checkout::generateUrlForStep(Checkout::STEP_COMPLETE, $order),
@@ -340,7 +340,7 @@ class NovalnetHelper
 
         $errorMsg = '';
 
-        $amount = number_format($order->getTotal(), 2)*100;
+        $amount = floatval(number_format($order->getTotal(), 2, '.', ''))*100;
 
         if (!($amount >= $minAmount)) {
             $errorMsg .= PHP_EOL.sprintf(specialchars($GLOBALS['TL_LANG']['MSC']['nn_guarantee_error_msg_amount']), sprintf('%0.2f', $minAmount / 100));

--- a/src/Helper/NovalnetHelper.php
+++ b/src/Helper/NovalnetHelper.php
@@ -191,7 +191,7 @@ class NovalnetHelper
     {
         $request['transaction'] = array(
           'payment_type'     => $this->paymentType[$currentPayment],
-          'amount'           => floatval(number_format($order->getTotal(), 2, '.', ''))*100,           
+          'amount'           => floor($order->getTotal() * 100),           
           'currency'         => $order->getCurrency(),          
           'system_url'       => \Environment::get('base') ,
           'return_url'       => \Environment::get('base') . Checkout::generateUrlForStep(Checkout::STEP_COMPLETE, $order),
@@ -340,7 +340,7 @@ class NovalnetHelper
 
         $errorMsg = '';
 
-        $amount = floatval(number_format($order->getTotal(), 2, '.', ''))*100;
+        $amount = floor($order->getTotal() * 100);
 
         if (!($amount >= $minAmount)) {
             $errorMsg .= PHP_EOL.sprintf(specialchars($GLOBALS['TL_LANG']['MSC']['nn_guarantee_error_msg_amount']), sprintf('%0.2f', $minAmount / 100));


### PR DESCRIPTION
Currently there is a critical error in the extension if the total of the payment exceeds 999.99. In that case the customer is only charged 1.00 USD/EUR/etc.

The reason is that `number_format` is used in order to transform the total number to a maximum of two decimal places. However, PHP's `number_format` will by default introduce a thousands separator. So for example, if the total amount is `1117`

```php
number_format($order->getTotal(), 2)
```

will result in

```
'1,117.00'
```

This then cannot be parsed as a number by PHP anymore and thus it is interpreted as `1` instead when casting to an integer or float by the multiplication operation.

This PR fixes that by using `floor($order->getTotal() * 100)` instead.