### PR TITLE
Fix error when shipping address is null

### DIFF
--- a/src/Helper/NovalnetHelper.php
+++ b/src/Helper/NovalnetHelper.php
@@ -124,24 +124,31 @@ class NovalnetHelper
               'country_code'      => strtoupper($objBillingAddress->country),
         );
 
-        $request['customer']['shipping'] = array(
-            'street'            => $objShippingAddress->street_1,
-              'city'              => $objShippingAddress->city,
-              'zip'               => $objShippingAddress->postal,
-              'country_code'      => strtoupper($objShippingAddress->country),
-        );
-        if ($request['customer']['billing'] == $request['customer']['shipping']) {
+        if (null === $objShippingAddress) {
             $request['customer']['shipping'] = array(
                 'same_as_billing' => 1
             );
         } else {
             $request['customer']['shipping'] = array(
-             'first_name' => $objShippingAddress->firstname,
-             'last_name' => $objShippingAddress->lastname,
-             'email' => $objShippingAddress->email,
-             );
-             if (!empty($objShippingAddress->company)) {
-                $request['customer']['shipping']['company'] = $objShippingAddress->company;
+                'street'            => $objShippingAddress->street_1,
+                'city'              => $objShippingAddress->city,
+                'zip'               => $objShippingAddress->postal,
+                'country_code'      => strtoupper($objShippingAddress->country),
+            );
+
+            if ($request['customer']['billing'] == $request['customer']['shipping']) {
+                $request['customer']['shipping'] = array(
+                    'same_as_billing' => 1
+                );
+            } else {
+                $request['customer']['shipping'] = array_merge($request['customer']['shipping'], array(
+                    'first_name' => $objShippingAddress->firstname,
+                    'last_name' => $objShippingAddress->lastname,
+                    'email' => $objShippingAddress->email,
+                ));
+                if (!empty($objShippingAddress->company)) {
+                    $request['customer']['shipping']['company'] = $objShippingAddress->company;
+                }
             }
         }
 


### PR DESCRIPTION
In Contao Isotope you can define products as "exempt from shipping". If the whole order consists only of products that are exempt from shipping, then no shipping address will be created for this order.

This then leads to the following error within the Novalnet extension:

```
TypeError:
strtoupper(): Argument #1 ($string) must be of type string, null given

  at vendor\novalnet-gateway\isotope-novalnet\src\Helper\NovalnetHelper.php:131
  at strtoupper(null)
     (vendor\novalnet-gateway\isotope-novalnet\src\Helper\NovalnetHelper.php:131)
  at NovalnetGateway\IsotopeNovalnetBundle\Helper\NovalnetHelper->formCustomerParameters(object(Order), array(…))
     (vendor\novalnet-gateway\isotope-novalnet\src\Helper\NovalnetHelper.php:56)
  at NovalnetGateway\IsotopeNovalnetBundle\Helper\NovalnetHelper->buildNovalnetParams(object(Order), 'novalnetcc')
     (vendor\novalnet-gateway\isotope-novalnet\src\Isotope\Model\Payment\NovalnetCreditcard.php:68)
  at NovalnetGateway\IsotopeNovalnetBundle\Isotope\Model\Payment\NovalnetCreditcard->checkoutForm(object(Order), object(IsotopeCheckoutController))
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Module\Checkout.php:240)
```

This PR fixes that by checking whether a shipping address is defined and if not sets `'same_as_billing' => 1` for the `customer.shipping` request data.