### PR TITLE
Make sure `json_decode` does not cause an error, plus PHP 8 fixes

### DIFF
--- a/src/Callback/NovalnetWebHook.php
+++ b/src/Callback/NovalnetWebHook.php
@@ -147,7 +147,7 @@ class NovalnetWebHook
 
             $this->receivedAmount = sprintf('%0.2f', $this->eventData['transaction']['amount'] / 100);
 
-            $this->orderId  = $this->eventData['transaction']['order_no'] ? $this->eventData['transaction']['order_no'] : $this->orderReference['order_no'];
+            $this->orderId  = ($this->eventData['transaction']['order_no'] ?? null) ? $this->eventData['transaction']['order_no'] : $this->orderReference['order_no'];
 
             switch ($this->eventType) {
                 case 'PAYMENT':
@@ -204,9 +204,9 @@ class NovalnetWebHook
         $this->validateChecksum();
 
         // Validate TID's from the event data
-        if (!preg_match('/^\d{17}$/', (string) $this->eventData['event']['tid'])) {
+        if (!preg_match('/^\d{17}$/', (string) ($this->eventData['event']['tid'] ?? null))) {
             $this->displayMessage(['message' => "Invalid event TID: " . $this->eventData['event']['tid'] . " received for the event(". $this->eventData['event']['type'] .")"]);
-        } elseif ($this->eventData['event']['parent_tid'] && !preg_match('/^\d{17}$/', (string) $this->eventData['event']['parent_tid'])) {
+        } elseif (($this->eventData['event']['parent_tid'] ?? null) && !preg_match('/^\d{17}$/', (string) $this->eventData['event']['parent_tid'])) {
             $this->displayMessage(['message' => "Invalid event TID: " . $this->eventData['event']['parent_tid'] . " received for the event(". $this->eventData['event']['type'] .")"]);
         }
     }
@@ -254,7 +254,7 @@ class NovalnetWebHook
         }
 
         $unSerializeData['order_no'] = $order->getDocumentNumber() ?: $order->getId();
-        $responseOrderNo = $this->eventData['transaction']['order_no'];
+        $responseOrderNo = $this->eventData['transaction']['order_no'] ?? null;
 
         if (!empty($responseOrderNo) && ($unSerializeData['order_no'] != $responseOrderNo)) {
             $this->displayMessage(['message' => "Order reference not matching"]);

--- a/src/Callback/NovalnetWebHook.php
+++ b/src/Callback/NovalnetWebHook.php
@@ -247,7 +247,12 @@ class NovalnetWebHook
     {
         $paymentData = \Database::getInstance()->prepare("SELECT document_number, payment_data FROM tl_iso_product_collection WHERE id=?")->execute($order->getId());
 
-        $unSerializeData = json_decode($paymentData->payment_data, true);
+        try {
+            $unSerializeData = json_decode((string) $paymentData->payment_data, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            $unSerializeData = [];
+        }
+
         $unSerializeData['order_no'] = $paymentData->document_number;
         $responseOrderNo = $this->eventData['transaction']['order_no'];
 

--- a/src/Callback/NovalnetWebHook.php
+++ b/src/Callback/NovalnetWebHook.php
@@ -253,10 +253,10 @@ class NovalnetWebHook
             $unSerializeData = [];
         }
 
-        $unSerializeData['order_no'] = $paymentData->document_number;
+        $unSerializeData['order_no'] = $order->getDocumentNumber() ?: $order->getId();
         $responseOrderNo = $this->eventData['transaction']['order_no'];
 
-        if (!empty($responseOrderNo) && ($paymentData->document_number != $responseOrderNo)) {
+        if (!empty($responseOrderNo) && ($unSerializeData['order_no'] != $responseOrderNo)) {
             $this->displayMessage(['message' => "Order reference not matching"]);
         }
 


### PR DESCRIPTION
Under certain circumstances, the following error can occur during the IPN request:

```
TypeError(code: 0): json_decode(): Argument #1 ($json) must be of type string, null given at vendor/novalnet-gateway/isotope-novalnet/src/Callback/NovalnetWebHook.php:250
```

This PR fixes that by making sure that:

* the argument is always a string
* any malformed JSON falls back to an empty array

This PR also fixes a bunch of other warnings that occur under PHP 8.